### PR TITLE
adding /monitor to the config server to monitor the

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
 			<version>2.6.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-bus-amqp</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,8 +16,13 @@ spring:
     show-sql: true
   profiles:
     active:
-#      - "qa"
+      #      - "qa"
       - "prod"
+  rabbitmq:
+    host: "localhost"
+    port: 5672
+    username: "guest"
+    password: "guest"
 management:
   endpoints:
     web:


### PR DESCRIPTION
changes in github and added the webhook so when we push anything into github centralized repo then it will hit /monitor path and all new changes will be reflected to all the microservices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated Spring Cloud Bus with AMQP support to enable messaging capabilities.
  - Added configuration for RabbitMQ, including host, port, and default credentials.

- **Chores**
  - Updated active Spring profile settings to use only the "prod" profile by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->